### PR TITLE
- Make ValidatableInterfaceElement conform to AnyObject so that it's …

### DIFF
--- a/Validator/Sources/UIKit+Validator/ValidatableInterfaceElement.swift
+++ b/Validator/Sources/UIKit+Validator/ValidatableInterfaceElement.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ObjectiveC
 
-public protocol ValidatableInterfaceElement {
+public protocol ValidatableInterfaceElement: AnyObject {
     
     associatedtype InputType: Validatable
     var inputValue: InputType? { get }


### PR DESCRIPTION
…properties can be assigned to without causing "Cannot assign to property: 'self' is immutable" errors.